### PR TITLE
Working ssl config

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -88,6 +88,8 @@ frontend:
 http:
   # Uncomment this to add a password (recommended!)
   api_password: !secret http_password
+  ssl_certificate: /etc/letsencrypt/live/homer.timt.org/fullchain.pem
+  ssl_key: /etc/letsencrypt/live/homer.timt.org/privkey.pem
 
 # Checks for available updates
 updater:


### PR DESCRIPTION
Introduced ssl following guide on ha site:

Followed the instructions here: https://home-assistant.io/blog/2015/12/13/setup-encryption-using-lets-encrypt/ with some minor mods (no duckdns,  no parameters to certbot etc.)

Not feeling too happy about having to chmod the live and archive subdirs, to allow homeassistant access. 

And ultimately, I want to put stuff behind a reverse proxy.. to be able to just go to homer.timt.org/homeassistant and be automatically connected to the right port 443

(And something didn't work with the port redirection of 443 -> 8123 on the fritzbox.. not sure why..